### PR TITLE
Validate account address and account name when watching an account.

### DIFF
--- a/src/features/dev-settings/DevSettingsScreen.js
+++ b/src/features/dev-settings/DevSettingsScreen.js
@@ -24,6 +24,7 @@ import {
   appSelectors,
   SUBSTRATE_NETWORKS,
 } from '../app/app-slice';
+import { UtilCryptoRpc } from "@docknetwork/react-native-sdk/src/client/util-crypto-rpc";
 
 export function DevSettingsScreen({onAddAccount, onNetworkChange}) {
   const [showNetworkOptions, setShowNetworkOptions] = useState();
@@ -157,15 +158,18 @@ export function DevSettingsScreen({onAddAccount, onNetworkChange}) {
                       message: translate('dev_settings.invalid_account_name'),
                       type: 'error',
                     });
+                    return
                   }
 
-                  if (!accountAddress) {
+                  const isAddressValid = await UtilCryptoRpc.isAddressValid(accountAddress);
+                  if (!accountAddress || !isAddressValid) {
                     showToast({
                       message: translate(
                         'dev_settings.invalid_account_address',
                       ),
                       type: 'error',
                     });
+                    return
                   }
 
                   onAddAccount({

--- a/src/features/dev-settings/DevSettingsScreen.js
+++ b/src/features/dev-settings/DevSettingsScreen.js
@@ -24,7 +24,7 @@ import {
   appSelectors,
   SUBSTRATE_NETWORKS,
 } from '../app/app-slice';
-import { UtilCryptoRpc } from "@docknetwork/react-native-sdk/src/client/util-crypto-rpc";
+import {UtilCryptoRpc} from '@docknetwork/react-native-sdk/src/client/util-crypto-rpc';
 
 export function DevSettingsScreen({onAddAccount, onNetworkChange}) {
   const [showNetworkOptions, setShowNetworkOptions] = useState();
@@ -158,10 +158,12 @@ export function DevSettingsScreen({onAddAccount, onNetworkChange}) {
                       message: translate('dev_settings.invalid_account_name'),
                       type: 'error',
                     });
-                    return
+                    return;
                   }
 
-                  const isAddressValid = await UtilCryptoRpc.isAddressValid(accountAddress);
+                  const isAddressValid = await UtilCryptoRpc.isAddressValid(
+                    accountAddress,
+                  );
                   if (!accountAddress || !isAddressValid) {
                     showToast({
                       message: translate(
@@ -169,7 +171,7 @@ export function DevSettingsScreen({onAddAccount, onNetworkChange}) {
                       ),
                       type: 'error',
                     });
-                    return
+                    return;
                   }
 
                   onAddAccount({


### PR DESCRIPTION
Problem: Currently the only validation been done only checks if the Account name field is empty or if the account address field is empty.

Solution: Apart from check if the account address is empty, another validation to check if the address is valid will be included.

Suggestion: Maybe include a "Paste" functionality in the account address field.

https://dock-team.atlassian.net/browse/DCK-2008