### PR TITLE
Sort Transaction history in descending order using date

### DIFF
--- a/src/features/accounts/AccountDetailsScreen.js
+++ b/src/features/accounts/AccountDetailsScreen.js
@@ -178,6 +178,7 @@ function TransactionHistory({accountAddress}) {
       <NBox>
         {transactions.map(item => (
           <TransactionHistoryItem
+            key={item.id}
             transaction={item}
             accountAddress={accountAddress}
           />

--- a/src/features/accounts/AccountDetailsScreen.js
+++ b/src/features/accounts/AccountDetailsScreen.js
@@ -122,6 +122,13 @@ function TransactionHistoryItem({transaction, accountAddress}) {
     </>
   );
 }
+export function sortTransactionHistory(transactions) {
+  return [...transactions].sort((a, b)=>{
+    const aDateTime = a.date ? new Date(a.date).getTime(): new Date().getTime()
+    const bDateTime = b.date ?  new Date(b.date).getTime(): new Date().getTime()
+    return bDateTime-aDateTime
+  });
+}
 
 export function filterTransactionHistory(transactions, accountAddress) {
   return transactions
@@ -147,11 +154,7 @@ function TransactionHistory({accountAddress}) {
 
   const transactions = useMemo(() => {
     const filteredTransactions = filterTransactionHistory(allTransactions, accountAddress);
-    return [...filteredTransactions].sort((a, b)=>{
-      const aDateTime = a.date ? new Date(a.date).getTime(): new Date().getTime()
-      const bDateTime = b.date ?  new Date(b.date).getTime(): new Date().getTime()
-      return bDateTime-aDateTime
-    });
+    return sortTransactionHistory(filteredTransactions)
   }, [allTransactions, accountAddress]);
 
   return useMemo(() => {

--- a/src/features/accounts/AccountDetailsScreen.js
+++ b/src/features/accounts/AccountDetailsScreen.js
@@ -123,10 +123,14 @@ function TransactionHistoryItem({transaction, accountAddress}) {
   );
 }
 export function sortTransactionHistory(transactions) {
-  return [...transactions].sort((a, b)=>{
-    const aDateTime = a.date ? new Date(a.date).getTime(): new Date().getTime()
-    const bDateTime = b.date ?  new Date(b.date).getTime(): new Date().getTime()
-    return bDateTime-aDateTime
+  return [...transactions].sort((a, b) => {
+    const aDateTime = a.date
+      ? new Date(a.date).getTime()
+      : new Date().getTime();
+    const bDateTime = b.date
+      ? new Date(b.date).getTime()
+      : new Date().getTime();
+    return bDateTime - aDateTime;
   });
 }
 
@@ -151,10 +155,12 @@ export function filterTransactionHistory(transactions, accountAddress) {
 function TransactionHistory({accountAddress}) {
   const allTransactions = useSelector(transactionsSelectors.getTransactions);
 
-
   const transactions = useMemo(() => {
-    const filteredTransactions = filterTransactionHistory(allTransactions, accountAddress);
-    return sortTransactionHistory(filteredTransactions)
+    const filteredTransactions = filterTransactionHistory(
+      allTransactions,
+      accountAddress,
+    );
+    return sortTransactionHistory(filteredTransactions);
   }, [allTransactions, accountAddress]);
 
   return useMemo(() => {

--- a/src/features/accounts/AccountDetailsScreen.js
+++ b/src/features/accounts/AccountDetailsScreen.js
@@ -143,8 +143,15 @@ export function filterTransactionHistory(transactions, accountAddress) {
 
 function TransactionHistory({accountAddress}) {
   const allTransactions = useSelector(transactionsSelectors.getTransactions);
+
+
   const transactions = useMemo(() => {
-    return filterTransactionHistory(allTransactions, accountAddress);
+    const filteredTransactions = filterTransactionHistory(allTransactions, accountAddress);
+    return [...filteredTransactions].sort((a, b)=>{
+      const aDateTime = a.date ? new Date(a.date).getTime(): new Date().getTime()
+      const bDateTime = b.date ?  new Date(b.date).getTime(): new Date().getTime()
+      return bDateTime-aDateTime
+    });
   }, [allTransactions, accountAddress]);
 
   return useMemo(() => {

--- a/src/features/accounts/AccountDetailsScreen.test.js
+++ b/src/features/accounts/AccountDetailsScreen.test.js
@@ -4,6 +4,7 @@ import configureMockStore from 'redux-mock-store';
 import {
   AccountDetailsScreen,
   filterTransactionHistory,
+  sortTransactionHistory
 } from './AccountDetailsScreen';
 
 const mockStore = configureMockStore();
@@ -30,6 +31,41 @@ describe('AccountDetailsScreen', () => {
     expect(wrapper.dive()).toMatchSnapshot();
   });
 
+  describe('expect transactions to be sorted by date in descending order', () => {
+    const address1 = '3C7Hq5jQGxeYzL7LnVASn48tEfr6D7yKtNYSuXcgioQoWWsB';
+    const address2 = '4C7Hq5jQGxeYzL7LnVASn48tEfr6D7yKtNYSuXcgioQoWWsB';
+
+    const txSent = {
+      id: 0,
+      amount: '1',
+      fromAddress: address1,
+      recipientAddress: address2,
+      status: 'complete',
+      date: "2022-03-03T17:52:03.741Z"
+    };
+
+    const txReceived = {
+      id: 2,
+      amount: '1',
+      fromAddress: address2,
+      recipientAddress: address1,
+      status: 'complete',
+      date: "2022-01-03T17:52:03.741Z"
+    };
+
+    const txSent2 = {
+      id: 1,
+      amount: '2',
+      fromAddress: address2,
+      recipientAddress: address1,
+      status: 'complete',
+      date: "2022-02-03T17:52:03.741Z"
+    };
+    const sortedTrans = sortTransactionHistory([txSent,txReceived, txSent2])
+    expect(sortedTrans[0].id).toBe(0);
+    expect(sortedTrans[1].id).toBe(1);
+    expect(sortedTrans[2].id).toBe(2);
+  });
   describe('expect to filter transaction history items', () => {
     const address1 = '3C7Hq5jQGxeYzL7LnVASn48tEfr6D7yKtNYSuXcgioQoWWsB';
     const address2 = '4C7Hq5jQGxeYzL7LnVASn48tEfr6D7yKtNYSuXcgioQoWWsB';

--- a/src/features/accounts/AccountDetailsScreen.test.js
+++ b/src/features/accounts/AccountDetailsScreen.test.js
@@ -4,7 +4,7 @@ import configureMockStore from 'redux-mock-store';
 import {
   AccountDetailsScreen,
   filterTransactionHistory,
-  sortTransactionHistory
+  sortTransactionHistory,
 } from './AccountDetailsScreen';
 
 const mockStore = configureMockStore();
@@ -41,7 +41,7 @@ describe('AccountDetailsScreen', () => {
       fromAddress: address1,
       recipientAddress: address2,
       status: 'complete',
-      date: "2022-03-03T17:52:03.741Z"
+      date: '2022-03-03T17:52:03.741Z',
     };
 
     const txReceived = {
@@ -50,7 +50,7 @@ describe('AccountDetailsScreen', () => {
       fromAddress: address2,
       recipientAddress: address1,
       status: 'complete',
-      date: "2022-01-03T17:52:03.741Z"
+      date: '2022-01-03T17:52:03.741Z',
     };
 
     const txSent2 = {
@@ -59,9 +59,9 @@ describe('AccountDetailsScreen', () => {
       fromAddress: address2,
       recipientAddress: address1,
       status: 'complete',
-      date: "2022-02-03T17:52:03.741Z"
+      date: '2022-02-03T17:52:03.741Z',
     };
-    const sortedTrans = sortTransactionHistory([txSent,txReceived, txSent2])
+    const sortedTrans = sortTransactionHistory([txSent, txReceived, txSent2]);
     expect(sortedTrans[0].id).toBe(0);
     expect(sortedTrans[1].id).toBe(1);
     expect(sortedTrans[2].id).toBe(2);


### PR DESCRIPTION
Problem:  Transaction history is retrieved from redux store and they are not been sorted

Solution: Sort the transactions after getting them from the store.


Link: https://dock-team.atlassian.net/browse/DCK-2005